### PR TITLE
Introduce an experimental option to save position every time when dragging nodes

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -122,14 +122,15 @@ class Diagram {
         // without path calculation
         this.configure_tick(group, node, link);
 
-        const position = PositionCache.load();
-        if (this.options.position_cache && position.match(data, this.options.group_pattern)) {
-          Group.set_position(group, position.group);
-          Node.set_position(node, position.node);
-          Link.set_position(link, position.link);
+        this.position_cache = PositionCache.load(data, this.options.group_pattern);
+        if (this.options.position_cache && this.position_cache) {
+          Group.set_position(group, this.position_cache.group);
+          Node.set_position(node, this.position_cache.node);
+          Link.set_position(link, this.position_cache.link);
         } else {
           this.ticks_forward();
-          this.save_position(group, node, link, data, this.options.group_pattern);
+          this.position_cache = new PositionCache(data, this.options.group_pattern);
+          this.save_position(group, node, link);
         }
 
         this.hide_load_message();
@@ -213,9 +214,8 @@ class Diagram {
       this.indicator.text(message);
   }
 
-  save_position(group, node, link, data, pop) {
-    const cache = new PositionCache(group, node, link, data, pop);
-    cache.save();
+  save_position(group, node, link) {
+    this.position_cache.save(group, node, link);
   }
 }
 

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -18,6 +18,7 @@ class Diagram {
     this.options.color = d3.scale.category20();
     this.options.max_ticks = options.ticks || 1000;
     this.options.position_cache = 'positionCache' in options ? options.positionCache : true;
+    // NOTE: This is an experimental option
     this.options.bundle = 'bundle' in options ? options.bundle : false;
 
     this.set_distance = this.link_distance(options.distance || 150);

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -141,7 +141,6 @@ class Diagram {
         if (this.options.bundle) {
           Link.shift_bundle(link, path, label);
         }
-        this.ticks_forward(1);
 
         path.attr('d', (d) => d.d());  // make sure path calculation is done
         this.freeze(node);

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -17,6 +17,7 @@ class Diagram {
 
     this.options.color = d3.scale.category20();
     this.options.max_ticks = options.ticks || 1000;
+    // NOTE: true or 'fixed' (experimental) affects behavior
     this.options.position_cache = 'positionCache' in options ? options.positionCache : true;
     // NOTE: This is an experimental option
     this.options.bundle = 'bundle' in options ? options.bundle : false;
@@ -125,6 +126,8 @@ class Diagram {
 
         this.position_cache = PositionCache.load(data, this.options.group_pattern);
         if (this.options.position_cache && this.position_cache) {
+          // NOTE: Evaluate only when positionCache: true or 'fixed', and
+          //       when the stored position cache matches pair of given data and pop
           Group.set_position(group, this.position_cache.group);
           Node.set_position(node, this.position_cache.node);
           Link.set_position(link, this.position_cache.link);
@@ -146,6 +149,13 @@ class Diagram {
 
         path.attr('d', (d) => d.d());  // make sure path calculation is done
         this.freeze(node);
+
+        // NOTE: This is an experimental option
+        if (this.options.position_cache === 'fixed') {
+          this.cola.on('end', () => {
+            this.save_position(group, node, link);
+          });
+        }
       } catch (e) {
         this.show_message(e);
         throw e;

--- a/src/position_cache.js
+++ b/src/position_cache.js
@@ -32,7 +32,13 @@ class PositionCache {
 
   sha1(data, pop) {
     data = Object.assign({}, data || this.data);
-    data.pop = pop || this.pop || null;  // NOTE: unify undefined with null
+    data.pop = pop || this.pop;
+    if (data.pop) {
+      data.pop = data.pop.toString();
+    } else {
+      data.pop = null;  // NOTE: unify undefined with null
+    }
+
     data.nodes && data.nodes.forEach((i) => {
       delete i.icon;
       delete i.meta;

--- a/src/position_cache.js
+++ b/src/position_cache.js
@@ -1,12 +1,11 @@
 const crypto = require('crypto');
 
 class PositionCache {
-  constructor(group, node, link, data, pop, sha1) {
-    this.group = group;
-    this.node = node;
-    this.link = link;
+  constructor(data, pop, sha1, group, node, link) {
     this.data = data;
     this.pop = pop;
+
+    // NOTE: properties below can be undefined
     this.cached_sha1 = sha1;
   }
 
@@ -18,13 +17,13 @@ class PositionCache {
     return this.get_all()[location.pathname] || {};
   }
 
-  save() {
+  save(group, node, link) {
     const cache = PositionCache.get_all();
     cache[location.pathname] = {
       sha1: this.sha1(),
-      group: this.group_position(),
-      node: this.node_position(),
-      link: this.link_position()
+      group: this.group_position(group),
+      node: this.node_position(node),
+      link: this.link_position(link)
     };
 
     localStorage.setItem('position_cache', JSON.stringify(cache));
@@ -52,10 +51,10 @@ class PositionCache {
     return sha1.digest('hex');
   }
 
-  group_position() {
+  group_position(group) {
     const position = [];
 
-    this.group.each((d) => {
+    group.each((d) => {
       position.push({
         x: d.bounds.x,
         y: d.bounds.y,
@@ -67,10 +66,10 @@ class PositionCache {
     return position;
   }
 
-  node_position() {
+  node_position(node) {
     const position = [];
 
-    this.node.each((d) => {
+    node.each((d) => {
       position.push({
         x: d.x,
         y: d.y
@@ -80,10 +79,10 @@ class PositionCache {
     return position;
   }
 
-  link_position() {
+  link_position(link) {
     const position = [];
 
-    this.link.each((d) => {
+    link.each((d) => {
       position.push({
         x1: d.source.x,
         y1: d.source.y,
@@ -99,12 +98,17 @@ class PositionCache {
     return this.cached_sha1 === this.sha1(data, pop);
   }
 
-  static load() {
+  static load(data, pop) {
     const cache = this.get();
     if (cache) {
-      return new PositionCache(cache.group, cache.node, cache.link, null, null, cache.sha1);
-    } else {
-      return new PositionCache();
+      const position = new PositionCache(data, pop, cache.sha1);
+      if (position.match(data, pop)) {  // if data and pop match saved sha1
+        position.group = cache.group;
+        position.node = cache.node;
+        position.link = cache.link;
+
+        return position;
+      }
     }
   }
 }


### PR DESCRIPTION
fix #8 

## How to try

Update example/index.html

```html
   <script>
-   var diagram = new Diagram('#diagram', 'index.json', {pop: /^([^\s-]+)-/, bundle: true});
+   var diagram = new Diagram('#diagram', 'index.json', {pop: /^([^\s-]+)-/, bundle: true, positionCache: 'fixed'});
    diagram.init('loopback', 'interface');
   </script>
```