### PR TITLE
Support to undisplay selected nodes

### DIFF
--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -170,6 +170,8 @@ export class Diagram {
             const linkLabelLayer = this.svg.append('g').attr('id', 'link-labels');
             const tooltipLayer = this.svg.append('g').attr('id', 'tooltips');
 
+            d3.select("body").on('keydown', this.hideNodes);
+
             const [link, path, label] = Link.render(linkLayer, linkLabelLayer, links);
 
             const group = Group.render(groupLayer, groups).call(
@@ -235,6 +237,30 @@ export class Diagram {
         } catch (e) {
             this.showMessage(e);
             throw e;
+        }
+    }
+
+    hideNodes(): void {
+        if ((event as KeyboardEvent).keyCode === 68) {
+            // hide nodes and links when "d" key pressed
+            const node = d3.selectAll('.node')
+            node.each(function (d) {
+                d.hideCallback(this);
+            });
+            const link = d3.selectAll('.link')
+            link.each(function (d) {
+                d.hideCallback(this);
+            });
+        } else if ((event as KeyboardEvent).keyCode === 27) {
+            // reset hidden nodes and links when escape key pressed
+            const node = d3.selectAll('.node')
+            node.each(function (d) {
+                d.showCallback(this);
+            });
+            const link = d3.selectAll('.link')
+            link.each(function (d) {
+                d.showCallback(this);
+            });
         }
     }
 

--- a/src/link.ts
+++ b/src/link.ts
@@ -28,6 +28,7 @@ export class Link {
     // Fix @types/d3/index.d.ts. Should be "d3.scale.Ordinal<number, string>" but "d3.scale.Ordinal<string, string>" somehow
     // Also, it should have accepted undefined
     private color: any;  // eslint-disable-line @typescript-eslint/no-explicit-any
+    private display: string;
     private _margin: number;
 
     constructor(data: LinkDataType, public id: number, metaKeys: string[], linkWidth: (object) => number) {
@@ -47,6 +48,7 @@ export class Link {
         this.labelXOffset = 20;
         this.labelYOffset = 1.5; // em
         this.color = '#7a4e4e';
+        this.display = '';
 
         this.register(id, this.source, this.target);
     }
@@ -137,6 +139,26 @@ export class Link {
         return `link ${classify((<Node>this.source).name)} ${classify((<Node>this.target).name)} ${classify((<Node>this.source).name)}-${classify((<Node>this.target).name)} ${this.extraClass}`;
     }
 
+    hide(): string {
+        if ((<Node>this.source).display === 'none' || (<Node>this.target).display ) {
+            this.display = 'none';
+            return 'none';
+        }
+    }
+
+    show(): string {
+        this.display = '';
+        return '';
+    }
+
+    showCallback(element: SVGGElement): void {
+        d3.select(element).style('display', this.show());
+    }
+
+    hideCallback(element: SVGGElement): void {
+        d3.select(element).style('display', this.hide());
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static render(linkLayer: d3.Selection<any>, labelLayer: d3.Selection<any>, links: Link[]): [d3.Selection<Link>, d3.Selection<Link>, d3.Selection<any>] {
         // Render lines
@@ -144,7 +166,8 @@ export class Link {
             .data(links)
             .enter()
             .append('g')
-            .attr('class', (d) => d.class());
+            .attr('class', (d) => d.class())
+            .style('display', (d) => d.display);
 
         const link = pathGroup.append('line')
             .attr('x1', (d) => (<Node>d.source).x)


### PR DESCRIPTION
This patch supports to undisplay selected nodes.
Namely, texts on selected nodes become red from black,
and a subsequent keyboard action removes the nodes with related links.